### PR TITLE
Change holiday table style

### DIFF
--- a/src/assets/data/2023.js
+++ b/src/assets/data/2023.js
@@ -71,36 +71,36 @@ const holidays = {
       name: 'Substitution for New Year`s Day (Saturday 1st January 2022)',
     },
     {
-      date: '2022-04-15',
+      date: '2022-04-7',
       name: 'Good Friday',
     },
     {
-      date: '2022-04-18',
+      date: '2022-04-10',
       name: 'Easter Monday',
     },
     {
-      date: '2022-05-02',
+      date: '2022-05-01',
       name: 'Early May Bank Holiday',
     },
     {
-      date: '2022-06-02',
+      date: '2022-05-08',
+      name: 'Bank holiday for the coronation of King Charles III',
+    },
+    {
+      date: '2022-05-29',
       name: 'Spring Bank Holiday',
     },
     {
-      date: '2022-06-03',
-      name: 'Platinum Jubilee bank holiday',
+      date: '2022-08-28',
+      name: 'Summer Bank Holiday',
     },
     {
-      date: '2022-08-29',
-      name: 'Summer Bank Holiday',
+      date: '2022-12-25',
+      name: 'Christmas Day',
     },
     {
       date: '2022-12-26',
       name: 'Boxing Day',
-    },
-    {
-      date: '2022-12-27',
-      name: 'Christmas Day',
     },
   ],
 }

--- a/src/components/HolidaysTable.js
+++ b/src/components/HolidaysTable.js
@@ -28,12 +28,6 @@ const ItemContainer = styled.div`
   padding: 15px;
 `
 
-const DateText = styled.h6`
-  display: inline-block;
-  margin-right: 5px;
-  color: ${(props) => (props.isHighlight ? 'white' : 'gray')};
-`
-
 const StyledLabel = styled(Label)`
   width: 200px;
   color: ${(props) => (props.isHighlight ? 'white' : 'gray')};
@@ -133,14 +127,11 @@ function HolidaysTable({
           .sort((a, b) => a.date - b.date)
           .map((holiday) => (
             <div key={holiday.date}>
-              <DateText isHighlight={!holiday.isDefaultHoliday}>
-                {holiday.date}
-              </DateText>
               <StyledLabel
                 isHighlight={!holiday.isDefaultHoliday}
                 line-clamp="1"
               >
-                {holiday.name}
+                {holiday.date} {holiday.name}
               </StyledLabel>
             </div>
           ))}


### PR DESCRIPTION
I propose to restructure holiday item on the table a bit by grouping date and label together so it can be wrapped properly. It will have slightly impacts on indent and bold style but I feel that in overall, this is better readability.

Before:
![Screenshot 2566-01-17 at 11 04 57](https://user-images.githubusercontent.com/81604092/212807637-b975cae0-4519-4e29-a865-eeb9962109c2.png)

After:
![Screenshot 2566-01-17 at 11 03 43](https://user-images.githubusercontent.com/81604092/212807688-c4da59f0-7da2-4460-93b2-feb9bc041b0b.png)
